### PR TITLE
make link to moment app clickable

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Prefer doing instead of reading?
 
-We recommend you check out https://app.moment.dev and try out our onboarding canvas.
+We recommend you check out [https://app.moment.dev](https://app.moment.dev) and try out our onboarding canvas.
 
 ## What is Moment?
 


### PR DESCRIPTION
GitBook's markdown renderer requires you to tag a url to make it clickable.